### PR TITLE
Rebuild for protobuf 3.12.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - normalize-ogre-path.patch  # [win]
 
 build:
-  number: 8
+  number: 9
   skip: false
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x.x') }}


### PR DESCRIPTION
Build currently fail because of 
```
$PREFIX/include/gazebo-11/gazebo/msgs/cessna.pb.h:56:51: error: no type named 'AuxillaryParseTableField' in namespace 'google::protobuf::internal'; did you mean 'AuxiliaryParseTableField'?
  static const ::PROTOBUF_NAMESPACE_ID::internal::AuxillaryParseTableField aux[]
```
Which was renamed in protobuf 3.12.3. Last build had protobuf 3.12.1